### PR TITLE
Support GHC 9.14

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,7 +11,10 @@ jobs:
           - '9.4'
           - '9.6'
           - '9.8'
-        cabal-version: ['3.10.2.0']
+          - '9.10'
+          - '9.12'
+          - '9.14'
+        cabal-version: ['3.16.1.0']
     steps:
       # Checkout
       - uses: actions/checkout@v3

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,7 +1,6 @@
-active-repositories: hackage.haskell.org:merge, owens-murray:merge
-constraints: any.base ==4.21.0.0,
-             any.ghc-bignum ==1.3,
-             any.ghc-internal ==9.1202.0,
-             any.ghc-prim ==0.13.0,
-             any.rts ==1.0.2
-index-state: hackage.haskell.org 2025-05-31T21:46:38Z
+active-repositories: hackage.haskell.org:merge
+constraints: any.base ==4.22.0.0,
+             any.ghc-internal ==9.1401.0,
+             any.ghc-prim ==0.13.1,
+             any.rts ==1.0.3
+index-state: hackage.haskell.org 2026-02-01T04:15:37Z

--- a/generic-enumeration.cabal
+++ b/generic-enumeration.cabal
@@ -19,7 +19,7 @@ extra-source-files:
 
 common dependencies
   build-depends:
-    , base >= 4.13.0.0 && < 4.22
+    , base >= 4.13.0.0 && < 4.23
 
 common warnings
   ghc-options:

--- a/generic-enumeration.cabal
+++ b/generic-enumeration.cabal
@@ -10,7 +10,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Rick Owens
 maintainer:          rick@owensmurray.com
-copyright:           2023 Rick Owens
+copyright:           2026 Rick Owens
 -- category:
 build-type:          Simple
 extra-source-files:

--- a/generic-enumeration.cabal
+++ b/generic-enumeration.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                generic-enumeration
-version:             0.1.0.4
+version:             0.1.0.5
 synopsis:            Generically derived enumerations.
 description:         This package provides a way to generically obtain
                      every possible value of a type, provided that the


### PR DESCRIPTION
Relax base upper bound to < 4.23 and update cabal.project.freeze
constraints for GHC 9.14 (base 4.22, ghc-internal 9.1401.0).